### PR TITLE
indexDefinition => index_definition

### DIFF
--- a/courseware/activities/section_3/vector_search.py
+++ b/courseware/activities/section_3/vector_search.py
@@ -1,6 +1,6 @@
 import redis
 from redis.commands.search.field import TextField, TagField, VectorField
-from redis.commands.search.indexDefinition import IndexDefinition
+from redis.commands.search.index_definition import IndexDefinition
 from redis.commands.search.query import Query
 import numpy as np
 from sentence_transformers import SentenceTransformer


### PR DESCRIPTION
## Summary

Fix incorrect import of `indexDefinition` in `vector_search.py`.

## Description

The script `vector_search.py` was failing due to an incorrect import statement for `indexDefinition`. According to recent changes in the upstream [redis/redis-py@0c242404](https://github.com/redis/redis-py/commit/0c242404d790fbcca9252be21eb63182f2834e7d), the correct import name is `index_definition` (snake_case), not `indexDefinition` (camelCase).  
This PR updates the import accordingly to restore compatibility and fix runtime errors.

## Changes

- Update import statement in `courseware/activities/section_3/vector_search.py`:
- Change `from redis.commands.search.indexDefinition import indexDefinition` to `from redis.commands.search.indexDefinition import index_definition`  


## Related References

- See [redis/redis-py@0c242404](https://github.com/redis/redis-py/commit/0c242404d790fbcca9252be21eb63182f2834e7d)